### PR TITLE
Add CMakeLists.txt project file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,41 +16,63 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.     #
 #############################################################################
 
-QT       += core gui
+message(STATUS "Using CMake version ${CMAKE_VERSION}")
+cmake_minimum_required(VERSION 3.1...${CMAKE_VERSION})
+project(libremines)
 
-greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
+    message(STATUS "Using default build type Release")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+endif()
 
-TARGET = libremines
-TEMPLATE = app
+# https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html
+string(COMPARE EQUAL "${CMAKE_CXX_STANDARD}" "" no_cmake_cxx_standard_set)
+if(no_cmake_cxx_standard_set)
+    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+    message(STATUS "Using default C++ standard ${CMAKE_CXX_STANDARD}")
+else()
+    message(STATUS "Using user specified C++ standard ${CMAKE_CXX_STANDARD}")
+endif()
 
-CONFIG += staticlib c++11
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+#set(CMAKE_AUTOUIC ON)
+
+add_executable(${PROJECT_NAME}
+    src/common.cpp
+    src/common.h
+    src/main.cpp
+    src/libremines.cpp
+    src/libremines.h
+    src/qpushbutton_adapted.cpp
+    src/qpushbutton_adapted.h
+    share/minesbollos.qrc
+)
 
 # The following define makes your compiler emit warnings if you use
 # any Qt feature that has been marked deprecated (the exact warnings
 # depend on your compiler). Please consult the documentation of the
 # deprecated API in order to know how to port your code away from it.
-DEFINES += QT_DEPRECATED_WARNINGS
+target_compile_definitions(${PROJECT_NAME} PRIVATE QT_DEPRECATED_WARNINGS)
 
 # You can also make your code fail to compile if it uses deprecated APIs.
 # In order to do so, uncomment the following line.
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
-#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+#target_compile_definitions(${PROJECT_NAME} PRIVATE QT_DISABLE_DEPRECATED_BEFORE=0x060000)    # disables all the APIs deprecated before Qt 6.0.0
 
-SOURCES += \
-    src/common.cpp \
-    src/main.cpp \
-    src/libremines.cpp \
-    src/qpushbutton_adapted.cpp
+find_package(Qt5 REQUIRED COMPONENTS Widgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Widgets)
 
-HEADERS += \
-    src/common.h \
-    src/libremines.h \
-    src/qpushbutton_adapted.h
+# create install target
+include(GNUInstallDirs)
+install(
+    TARGETS
+    ${PROJECT_NAME}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} # set include path for installed library target
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 
-RESOURCES += \
-    share/minesbollos.qrc
-
-# Default rules for deployment.
-qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /opt/$${TARGET}/bin
-!isEmpty(target.path): INSTALLS += target

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ The following dependencies are required for building and running LibreMines:
 
 
 On Arch Linux and derivatives systems the dependencies can be installed with pacman:
-```
-sudo pacman -S base-devel qt5-base
+```sh
+sudo pacman -S base-devel qt5-base cmake
 ```
 
 For ubuntu you can install the dependencies with the following command:
-```
-sudo apt-get install build-essential qt5-default
+```sh
+sudo apt-get install build-essential qt5-default cmake
 ```
 
 For others systems, check the [qt online installers](https://download.qt.io/official_releases/online_installers/).
@@ -25,17 +25,16 @@ For others systems, check the [qt online installers](https://download.qt.io/offi
 ### Building
 
 Follow those steps for build LibreMines from source code:
-```
+```sh
 git clone https://github.com/Bollos00/LibreMines.git
 cd LibreMines
-mkdir build && cd build
-qmake .. CONFIG+=release
-make
+cmake -S . -B build
+cmake --build build
 ```
 
-The executable `libremines` will be generated on the working directory, now it is possible to run it with:
-```
-./libremines
+The executable `libremines` will be generated in the build directory, now it is possible to run it with:
+```sh
+./build/libremines
 ```
 
 ## How to play


### PR DESCRIPTION
To build the project use the following commands:

```sh
cmake -S . -B build -DCMAKE_INSTALL_PREFIX="${PWD}/install"
cmake --build build -j4 --target install
```

The `CMAKE_INSTALL_PREFIX` part is optional, but enables you to set the
installation directory.

The above commands use an "out of source" build. This means all the
build files are in the specified build folder `build`. This helps keep
the repository clean of generated files, and makes it easier to switch
between build types, C++ standards or other things to try out.

The above commands are OS independent, which means you can build with
the commands on different platforms.

To build a 'Debug' build use the variable `CMAKE_BUILD_TYPE`. For
example:

```sh
cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
cmake --build build -j4
```

The `-j4` is used to build with 4 parallel threads. This can be any
number or with `-j` all the possible threads are used.