### PR TITLE
Upgrade to version 1.6.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 cmake_minimum_required(VERSION 3.1.0)
 project(libremines
-    VERSION "1.6.0"
+    VERSION "1.6.1"
     DESCRIPTION "A Qt based Minesweeper game"
     HOMEPAGE_URL "https://github.com/Bollos00/LibreMines"
     LANGUAGES "CXX"

--- a/README.md
+++ b/README.md
@@ -127,9 +127,15 @@ For activate the keyboard controller mode, press one of the following keys: **A|
 
 * **P**: Flag/Unflag Current Cell;
 
+* **Space**: Locate current cell on middle of the scroll bar;
+
+* **CTRL + R**: Retart the game;
+
+* **CTRL + SHIFT + P**: Save minefield as image;
+
 If you do not feel comfortable with those keys, you can edit them going to the main menu, then Options > Preferences.
 
-Tip: hold the **Control Key** while moving to move faster.
+Tip: hold the **CTRL** modifier while moving in order to move faster.
 
 
 ## Contributing
@@ -143,7 +149,7 @@ All kinds of contributions are welcome on this project. You can help:
 * Packaging the software for other distributions;
 * Increasing the playability and adding new features by making changes on the source code.
 
-# Third party Repositories
+# Third party Repositories used in this software
 * [BreezeStyleSheets](https://github.com/Alexhuszagh/BreezeStyleSheets)
 * [GTRONICK/QSS](https://github.com/GTRONICK/QSS)
 * [QDarkStyleSheet](https://github.com/ColinDuquesnoy/QDarkStyleSheet)

--- a/src/common.h
+++ b/src/common.h
@@ -81,6 +81,8 @@ struct KeyboardController
     int keyUp;
     int keyReleaseCell;
     int keyFlagCell;
+    int keyCenterCell;
+
     bool valid;
 };
 

--- a/src/libreminesgui.cpp
+++ b/src/libreminesgui.cpp
@@ -228,6 +228,11 @@ bool LibreMinesGui::eventFilter(QObject* object, QEvent* event)
                     Q_EMIT SIGNAL_addOrRemoveFlag(controller.currentX, controller.currentY);
                     return true;
                 }
+                if(key == Qt::Key_Space)
+                {
+                    vKeyboardControllerCenterCurrentCell();
+                    return true;
+                }
                 if(key == Qt::Key_Escape)
                 {
                     controller.active = false;
@@ -1742,6 +1747,9 @@ void LibreMinesGui::vKeyboardControllerSetCurrentCell(const uchar x, const uchar
 
         cellGui.label->setPixmap(QPixmap::fromImage(img));
     }
+
+    scrollAreaBoard->ensureVisible(x*cellLength + cellLength/2, y*cellLength + cellLength/2,
+                                   cellLength/2 + 1, cellLength/2 + 1);
 }
 
 void LibreMinesGui::vKeyboardControllUnsetCurrentCell()
@@ -1915,6 +1923,15 @@ void LibreMinesGui::vKeyboardControllerMoveUp()
     }
 
     vKeyboardControllerSetCurrentCell(controller.currentX, destY);
+}
+
+void LibreMinesGui::vKeyboardControllerCenterCurrentCell()
+{
+    const uchar x = controller.currentX;
+    const uchar y = controller.currentY;
+    scrollAreaBoard->ensureVisible(x*cellLength + cellLength/2, y*cellLength + cellLength/2,
+                                   cellLength/2 + scrollAreaBoard->width()/2, cellLength/2 + scrollAreaBoard->height()/2);
+
 }
 
 void LibreMinesGui::vLastSessionLoadConfigurationFile()

--- a/src/libreminesgui.h
+++ b/src/libreminesgui.h
@@ -210,6 +210,8 @@ private Q_SLOTS:
 
     void SLOT_toggleFullScreen();
 
+    void SLOT_saveMinefieldAsImage();
+
 Q_SIGNALS:
     void SIGNAL_cleanCell(const uchar _X, const uchar _Y);
     void SIGNAL_cleanNeighborCells(const uchar _X, const uchar _Y);
@@ -252,6 +254,7 @@ private:
     QProgressBar* progressBarGameCompleteInGame;
     QPushButton *buttonRestartInGame; /**< TODO: describe */
     QPushButton *buttonQuitInGame; /**< TODO: describe */
+    QPushButton* buttonSaveMinefieldAsImage;
 
     QScrollArea* scrollAreaBoard;
     QWidget* widgetBoardContents;

--- a/src/libreminesgui.h
+++ b/src/libreminesgui.h
@@ -133,6 +133,7 @@ private:
     void vKeyboardControllerMoveRight();
     void vKeyboardControllerMoveDown();
     void vKeyboardControllerMoveUp();
+    void vKeyboardControllerCenterCurrentCell();
 
     void vLastSessionLoadConfigurationFile();
     void vLastSessionSaveConfigurationFile();

--- a/src/libreminespreferencesdialog.cpp
+++ b/src/libreminespreferencesdialog.cpp
@@ -89,6 +89,7 @@ LibreMinesPreferencesDialog::LibreMinesPreferencesDialog(QWidget *parent) :
     ui->keyInputMoveDown->setKey(Qt::Key_S);
     ui->keyInputReleaseCell->setKey(Qt::Key_O);
     ui->keyInputFlagCell->setKey(Qt::Key_P);
+    ui->keyInputCenterCell->setKey(Qt::Key_Space);
 }
 
 LibreMinesPreferencesDialog::~LibreMinesPreferencesDialog()
@@ -251,7 +252,8 @@ QList<int> LibreMinesPreferencesDialog::optionKeyboardControllerKeys() const
         ui->keyInputMoveRight->currentKey(),
         ui->keyInputMoveDown->currentKey(),
         ui->keyInputReleaseCell->currentKey(),
-        ui->keyInputFlagCell->currentKey()
+        ui->keyInputFlagCell->currentKey(),
+        ui->keyInputCenterCell->currentKey()
     };
 }
 
@@ -270,6 +272,8 @@ QString LibreMinesPreferencesDialog::optionKeyboardControllerKeysString() const
     s += QString::number(ui->keyInputReleaseCell->currentKey(), 16);
     s += ' ';
     s += QString::number(ui->keyInputFlagCell->currentKey(), 16);
+    s += ' ';
+    s += QString::number(ui->keyInputCenterCell->currentKey(), 16);
 
     return s;
 }
@@ -282,6 +286,10 @@ void LibreMinesPreferencesDialog::setOptionKeyboardControllerKeys(const QList<in
     ui->keyInputMoveDown->setKey(keys.at(3));
     ui->keyInputReleaseCell->setKey(keys.at(4));
     ui->keyInputFlagCell->setKey(keys.at(5));
+    if(keys.size() == 7)
+    {
+        ui->keyInputCenterCell->setKey(keys.at(6));
+    }
 }
 
 void LibreMinesPreferencesDialog::closeEvent(QCloseEvent *e)

--- a/src/libreminespreferencesdialog.ui
+++ b/src/libreminespreferencesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>767</width>
-    <height>487</height>
+    <width>687</width>
+    <height>562</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -315,6 +315,39 @@ clicked on showed cell</string>
         </item>
         <item>
          <widget class="QKeyInput" name="keyInputFlagCell">
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>100</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_15">
+        <item>
+         <widget class="QLabel" name="label_8">
+          <property name="text">
+           <string>Center cell on the scroll area</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QKeyInput" name="keyInputCenterCell">
           <property name="minimumSize">
            <size>
             <width>100</width>

--- a/src/qkeyinput.cpp
+++ b/src/qkeyinput.cpp
@@ -77,8 +77,10 @@ QString QKeyInput::getTextFromKey(const int k)
         case Qt::Key_N: return "N";
         case Qt::Key_O: return "O";
         case Qt::Key_P: return "P";
-        case Qt::Key_Q: return "Q";
-        case Qt::Key_R: return "R";
+        // Those two are invalid key, for they are used in specific
+        //  shortcur with the 'ctrl' modifier
+//        case Qt::Key_Q: return "Q";
+//        case Qt::Key_R: return "R";
         case Qt::Key_S: return "S";
         case Qt::Key_T: return "T";
         case Qt::Key_U: return "U";

--- a/src/qlabel_adapted.cpp
+++ b/src/qlabel_adapted.cpp
@@ -24,7 +24,7 @@
 QLabel_adapted::QLabel_adapted(QWidget *parent):
     QLabel(parent)
 {
-
+    setFocusPolicy(Qt::ClickFocus);
 }
 
 void QLabel_adapted::mouseReleaseEvent(QMouseEvent *e)

--- a/src/qpushbutton_adapted.cpp
+++ b/src/qpushbutton_adapted.cpp
@@ -23,7 +23,7 @@
 
 QPushButton_adapted::QPushButton_adapted(QWidget *parent) : QPushButton(parent)
 {
-
+    setFocusPolicy(Qt::ClickFocus);
 }
 
 


### PR DESCRIPTION
* Option to save minefield as image;

* With big boards, when using the keyboard controller, the current cell will always be visible;

* Command to center the current cell with the keyboard controller (default key: SPACE).