### PR TITLE
mine counter ushort to short

### DIFF
--- a/src/libreminesgameengine.cpp
+++ b/src/libreminesgameengine.cpp
@@ -38,7 +38,7 @@ LibreMinesGameEngine::LibreMinesGameEngine()
 
 void LibreMinesGameEngine::vNewGame(const uchar _X,
                                     const uchar _Y,
-                                    ushort i_nMines_,
+                                    short i_nMines_,
                                     const uchar i_X_Clean,
                                     const uchar i_Y_Clean)
 {
@@ -511,7 +511,7 @@ uchar LibreMinesGameEngine::lines() const
     return iY;
 }
 
-ushort LibreMinesGameEngine::mines() const
+short LibreMinesGameEngine::mines() const
 {
     return nMines;
 }

--- a/src/libreminesgameengine.h
+++ b/src/libreminesgameengine.h
@@ -47,14 +47,14 @@ public:
     LibreMinesGameEngine();
     void vNewGame(const uchar _X,
                   const uchar _Y,
-                  ushort i_nMines_,
+                  short i_nMines_,
                   const uchar i_X_Clean = 255,
                   const uchar i_Y_Clean = 255);
 
     const std::vector< std::vector<CellGameEngine> >& getPrincipalMatrix()const;
     uchar rows()const;
     uchar lines()const;
-    ushort mines()const;
+    short mines()const;
     ushort cellsToUnlock()const;
     ushort hiddenCells()const;
     bool isGameActive()const;
@@ -83,8 +83,8 @@ private:
     uchar iX; /**< TODO: describe */
     uchar iY; /**< TODO: describe */
 
-    ushort nMines; /**< TODO: describe */
-    ushort iMinesLeft; /**< TODO: describe */
+    short nMines; /**< TODO: describe */
+    short iMinesLeft; /**< TODO: describe */
     ushort iHiddenCells; /**< TODO: describe */
     ushort iCellsToUnlock; /**< TODO: describe */
 
@@ -108,7 +108,7 @@ Q_SIGNALS:
                              double dCellsPerSecond,
                              bool ignorePreferences=false);
     void SIGNAL_currentTime(const ushort);
-    void SIGNAL_minesLeft(const ushort);
+    void SIGNAL_minesLeft(const short);
     void SIGNAL_flagCell(const uchar _X, const uchar _Y);
     void SIGNAL_questionCell(const uchar _X, const uchar _Y);
     void SIGNAL_unflagCell(const uchar _X, const uchar _Y);

--- a/src/libreminesgui.cpp
+++ b/src/libreminesgui.cpp
@@ -169,6 +169,7 @@ void LibreMinesGui::vNewGame(const uchar _X,
                              short i_nMines_)
 {
     bMinefieldBeingCreated = true;
+    
     vAdjustInterfaceInGame();
     vShowInterfaceInGame();
 

--- a/src/libreminesgui.cpp
+++ b/src/libreminesgui.cpp
@@ -166,10 +166,9 @@ void LibreMinesGui::closeEvent(QCloseEvent *e)
 
 void LibreMinesGui::vNewGame(const uchar _X,
                              const uchar _Y,
-                             ushort i_nMines_)
+                             short i_nMines_)
 {
     bMinefieldBeingCreated = true;
-
     vAdjustInterfaceInGame();
     vShowInterfaceInGame();
 
@@ -1327,7 +1326,7 @@ void LibreMinesGui::SLOT_currentTime(const ushort time)
 //    Q_EMIT(sound->SIGNAL_clockTick());
 }
 
-void LibreMinesGui::SLOT_minesLeft(const ushort minesLeft)
+void LibreMinesGui::SLOT_minesLeft(const short minesLeft)
 {
     lcd_numberMinesLeft->display(minesLeft);
 }

--- a/src/libreminesgui.h
+++ b/src/libreminesgui.h
@@ -92,7 +92,7 @@ protected:
 private:
     void vNewGame(const uchar _X,
                   const uchar _Y,
-                  ushort i_nMines_);
+                  short i_nMines_);
 
     void vAttributeAllCells();
     void vResetPrincipalMatrix();
@@ -185,7 +185,7 @@ private Q_SLOTS:
                            double dCellsPerSecond,
                            bool ignorePreferences=false);
     void SLOT_currentTime(const ushort time);
-    void SLOT_minesLeft(const ushort minesLeft);
+    void SLOT_minesLeft(const short minesLeft);
     void SLOT_flagCell(const uchar _X, const uchar _Y);
     void SLOT_QuestionCell(const uchar _X, const uchar _Y);
     void SLOT_unflagCell(const uchar _X, const uchar _Y);

--- a/src/libreminesscore.h
+++ b/src/libreminesscore.h
@@ -34,7 +34,7 @@ public:
     GameDifficulty gameDifficulty;
     uchar width;
     uchar heigth;
-    ushort mines;
+    short mines;
     bool bGameCompleted;
     double dPercentageGameCompleted;
     QString username;


### PR DESCRIPTION
Upon the mine counter reaching 0, flagging another mine would make the counter wrap around to the maximum value of ushort. To fix this, all occurrences (or at least the ones that made it work) of mines had their types changed from ushort to short. The mine counter will now go negative, which may seem much more intuitive to the player.

Also, this is my first time contributing on GitHub! I really like this game and I decided that I should try to fix the counter issue, even if I am the only one that really cares.