### PR TITLE
Fix infinite loop in SLOT_cleanCell when too many mines are configured

### DIFF
--- a/src/libreminesgameengine.cpp
+++ b/src/libreminesgameengine.cpp
@@ -546,7 +546,18 @@ void LibreMinesGameEngine::SLOT_cleanCell(const uchar _X, const uchar _Y)
 {
     if(bFirst && bFirstCellClean && principalMatrix[_X][_Y].value != CellValue::ZERO)
     {
-        vNewGame(iX, iY, nMines, _X, _Y);
+        // Check if it's impossible to place all mines while keeping the clicked cell and its neighbors clean
+        // This prevents infinite loop when nMines > (total cells - 9)
+        const int totalCells = iX * iY;
+        const int minRequiredFreeCells = 9; // clicked cell + 8 neighbors
+        
+        // Cannot guarantee 9 free cells, so don't regenerate the game
+        // Just start the timer and proceed with current mine layout
+        if(nMines <= (totalCells - minRequiredFreeCells))
+        {
+            vNewGame(iX, iY, nMines, _X, _Y);
+        }
+        
         SLOT_startTimer();
         bFirst = false;
     }


### PR DESCRIPTION
This commit resolves issue #61 where the application would stop responding when creating customized games with high mine density.

Problem:
- When 'Clean neighbor cells when clicked on showed cell' preference is enabled
- And a customized game is created with mines > (total_cells - 9)
- The vNewGame() method would enter an infinite loop trying to place mines
- This occurred because it's impossible to guarantee 9 mine-free cells (clicked cell + 8 neighbors) when mine density is too high

Solution:
- Added validation in SLOT_cleanCell() before calling vNewGame()
- Check if nMines > (iX * iY - 9) before regenerating the game layout
- If condition is true, skip vNewGame() and proceed with existing layout
- This prevents the infinite loop while maintaining game functionality

Testing performed:
- Verified fix works with games having less than 9 available cells
- Confirmed vNewGame() is bypassed when mine density is too high
- Application no longer freezes on high-density customized games
- Normal gameplay remains unaffected for reasonable mine configurations

Closes #61