### PR TITLE
Fix timer interval to 100 ms to resolve display issue #83

### DIFF
--- a/src/libreminesgameengine.cpp
+++ b/src/libreminesgameengine.cpp
@@ -618,7 +618,9 @@ void LibreMinesGameEngine::SLOT_startTimer()
     QObject::connect(timerTimeInGame.get(), &QTimer::timeout,
                      this, &LibreMinesGameEngine::SLOT_UpdateTime);
 
-    timerTimeInGame->start(1000);
+    // reduce the timer interval to 100 ms.
+    // This fixes issue #83 where the display timer was one second ahead of real time
+    timerTimeInGame->start(100);
     elapsedPreciseTimeInGame.start();
 }
 

--- a/src/libreminesgui.cpp
+++ b/src/libreminesgui.cpp
@@ -1202,6 +1202,9 @@ void LibreMinesGui::SLOT_endGameScore(LibreMinesScore score,
     widgetEndGameResultsContents->adjustSize();
     scrollAreaEndGameResults->show();
 
+    // Update the timer label to avoid this being shown different from statistics time (#83).
+    labelTimerInGame->setNum(static_cast<int>(score.iTimeInNs*1e-9));
+
     score.gameDifficulty = difficult;
     score.username = preferences->optionUsername();
     if(score.username.isEmpty())


### PR DESCRIPTION
Solves #83

Now the timer display is being updated 10x for second, so it is more accurate to the actual game time. Also, at the end of the game, the timer display valeue is also updated one time more.